### PR TITLE
fix: replace sample code with specific name for this plugin

### DIFF
--- a/plugin/vim_codex.vim
+++ b/plugin/vim_codex.vim
@@ -3,7 +3,7 @@ if !has("python3")
   finish
 endif
 
-if exists('g:sample_python_plugin_loaded')
+if exists('g:vim_codex_loaded')
     finish
 endif
 
@@ -38,4 +38,4 @@ command! -nargs=0 CreateCompletionLine call CreateCompletionLine()
 map <Leader>co :CreateCompletion<CR>
 
 
-let g:sample_python_plugin_loaded = 1
+let g:vim_codex_loaded = 1


### PR DESCRIPTION
This replaces two instances of `sample_python_plugin` with a specific plugin name. Those are probably leftovers from copying a sample python plugin that should be changed.