### PR TITLE
Update deprecated model to text-davinci-003

### DIFF
--- a/python/plugin.py
+++ b/python/plugin.py
@@ -54,7 +54,7 @@ def initialize_openai_api():
 
 def complete_input_max_length(input_prompt, max_input_length=MAX_SUPPORTED_INPUT_LENGTH, stop=None, max_tokens=64):
     input_prompt = input_prompt[-max_input_length:]
-    response = openai.Completion.create(engine='code-davinci-001', prompt=input_prompt, best_of=1, temperature=0.5, max_tokens=max_tokens, stream=USE_STREAM_FEATURE, stop=stop)
+    response = openai.Completion.create(engine='text-davinci-003', prompt=input_prompt, best_of=1, temperature=0.5, max_tokens=max_tokens, stream=USE_STREAM_FEATURE, stop=stop)
     return response
 
 def complete_input(input_prompt, stop, max_tokens):


### PR DESCRIPTION
Resolves #22 by updating to `text-davinci-003`, a maintained model of gpt-3, which can handle code just fine. From my testing, functionality works fine, and this seems like the simplest solution.